### PR TITLE
refactor: replace vote system with score-based feedback model

### DIFF
--- a/src/components/vote-feedback.stories.tsx
+++ b/src/components/vote-feedback.stories.tsx
@@ -57,7 +57,7 @@ You have complete control over the appearance and can build your own design syst
 The headless approach separates the "brain" (logic) from the "looks" (styling). This gives you maximum flexibility while handling all the complex accessibility and interaction logic for you.
 
 ## API:
-- **type**: Uses 'upvote' | 'downvote' literal types
+- **score**: Uses numeric score (1 for upvote, 0 for downvote)
 - **Components**: UpvoteButton, DownvoteButton
 
 ## Accessibility Features:
@@ -78,7 +78,7 @@ The headless approach separates the "brain" (logic) from the "looks" (styling). 
       control: "text",
       description: "Required session ID for tracking feedback",
     },
-    extra_metadata: {
+    metadata: {
       control: "object",
       description: "Optional metadata to include with feedback",
     },
@@ -112,10 +112,14 @@ export const HeadlessBasic: Story = {
     // Assert upvote is selected and downvote is not
     await expect(upvoteButton).toHaveTextContent("(Selected)")
     await expect(downvoteButton).not.toHaveTextContent("(Selected)")
-    await expect(args.onFeedback).toHaveBeenCalledWith({
-      session_id: "story-demo",
-      vote: "upvote",
-    })
+    await expect(args.onFeedback).toHaveBeenCalledWith(
+      expect.objectContaining({
+        session_id: "story-demo",
+        kind: "feedback",
+        source: "human",
+        score: 1,
+      })
+    )
 
     // 3. Click downvote
     await userEvent.click(downvoteButton)
@@ -123,10 +127,14 @@ export const HeadlessBasic: Story = {
     // Assert downvote is selected and upvote is not
     await expect(downvoteButton).toHaveTextContent("(Selected)")
     await expect(upvoteButton).not.toHaveTextContent("(Selected)")
-    await expect(args.onFeedback).toHaveBeenCalledWith({
-      session_id: "story-demo",
-      vote: "downvote",
-    })
+    await expect(args.onFeedback).toHaveBeenCalledWith(
+      expect.objectContaining({
+        session_id: "story-demo",
+        kind: "feedback",
+        source: "human",
+        score: 0,
+      })
+    )
   },
   render: (args) => (
     <VoteFeedback.Root {...args}>
@@ -248,11 +256,15 @@ export const HeadlessCustomStyling: Story = {
     const submitButton = canvas.getByText("Submit Feedback")
     await userEvent.click(submitButton)
 
-    await expect(args.onFeedback).toHaveBeenCalledWith({
-      session_id: "story-demo",
-      vote: "downvote",
-      explanation: "Could be improved",
-    })
+    await expect(args.onFeedback).toHaveBeenCalledWith(
+      expect.objectContaining({
+        session_id: "story-demo",
+        kind: "feedback",
+        source: "human",
+        score: 0,
+        value: "Could be improved",
+      })
+    )
   },
   render: (args) => (
     <VoteFeedback.Root {...args}>
@@ -367,10 +379,14 @@ export const HeadlessMinimal: Story = {
     const sendButton = canvas.getByText("Send")
     await userEvent.click(sendButton)
 
-    await expect(args.onFeedback).toHaveBeenCalledWith({
-      session_id: "story-demo",
-      vote: "downvote",
-    })
+    await expect(args.onFeedback).toHaveBeenCalledWith(
+      expect.objectContaining({
+        session_id: "story-demo",
+        kind: "feedback",
+        source: "human",
+        score: 0,
+      })
+    )
   },
   render: (args) => (
     <VoteFeedback.Root {...args}>
@@ -455,7 +471,7 @@ export const HeadlessMinimal: Story = {
 export const AsChildPattern: Story = {
   args: {
     session_id: "as-child-demo",
-    extra_metadata: {
+    metadata: {
       testId: "as-child-pattern",
     },
   },
@@ -483,25 +499,33 @@ The \`asChild\` pattern is inspired by Radix UI and allows maximum flexibility w
     const customUpvote = canvas.getByTestId("custom-upvote")
     await userEvent.click(customUpvote)
 
-    await expect(args.onFeedback).toHaveBeenCalledWith({
-      session_id: "as-child-demo",
-      extra_metadata: {
-        testId: "as-child-pattern",
-      },
-      vote: "upvote",
-    })
+    await expect(args.onFeedback).toHaveBeenCalledWith(
+      expect.objectContaining({
+        session_id: "as-child-demo",
+        kind: "feedback",
+        source: "human",
+        score: 1,
+        metadata: {
+          testId: "as-child-pattern",
+        },
+      })
+    )
 
     // Test custom downvote element
     const customDownvote = canvas.getByTestId("custom-downvote")
     await userEvent.click(customDownvote)
 
-    await expect(args.onFeedback).toHaveBeenLastCalledWith({
-      session_id: "as-child-demo",
-      extra_metadata: {
-        testId: "as-child-pattern",
-      },
-      vote: "downvote",
-    })
+    await expect(args.onFeedback).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        session_id: "as-child-demo",
+        kind: "feedback",
+        source: "human",
+        score: 0,
+        metadata: {
+          testId: "as-child-pattern",
+        },
+      })
+    )
 
     // Test custom textarea
     const customTextarea = canvas.getByTestId("custom-textarea")
@@ -511,14 +535,18 @@ The \`asChild\` pattern is inspired by Radix UI and allows maximum flexibility w
     const customSubmit = canvas.getByTestId("custom-submit")
     await userEvent.click(customSubmit)
 
-    await expect(args.onFeedback).toHaveBeenLastCalledWith({
-      session_id: "as-child-demo",
-      extra_metadata: {
-        testId: "as-child-pattern",
-      },
-      vote: "downvote",
-      explanation: "Using custom elements!",
-    })
+    await expect(args.onFeedback).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        session_id: "as-child-demo",
+        kind: "feedback",
+        source: "human",
+        score: 0,
+        value: "Using custom elements!",
+        metadata: {
+          testId: "as-child-pattern",
+        },
+      })
+    )
 
     // Verify accessibility attributes are applied to custom elements
     expect(customUpvote).toHaveAttribute("aria-label", "Upvote feedback")
@@ -697,7 +725,7 @@ The \`asChild\` pattern is inspired by Radix UI and allows maximum flexibility w
 export const CompleteWorkflow: Story = {
   args: {
     session_id: "workflow-test",
-    extra_metadata: {
+    metadata: {
       userId: "user-123",
       sessionId: "session-456",
     },
@@ -711,7 +739,7 @@ export const CompleteWorkflow: Story = {
 1. **Upvote flow** - Click thumbs up and see action logged
 2. **Downvote with text** - Open popover, type feedback, submit
 3. **Empty submit** - Submit without text just closes popover
-4. **Metadata inclusion** - All callbacks include session_id and extra_metadata
+4. **Metadata inclusion** - All callbacks include session_id and metadata
 
 Watch the **Interactions** panel to see automated testing, and **Actions** panel for callback data!
         `,
@@ -725,56 +753,72 @@ Watch the **Interactions** panel to see automated testing, and **Actions** panel
     const upvoteButton = canvas.getByText("👍 Like")
     await userEvent.click(upvoteButton)
 
-    await expect(args.onFeedback).toHaveBeenCalledWith({
-      session_id: "workflow-test",
-      extra_metadata: {
-        userId: "user-123",
-        sessionId: "session-456",
-      },
-      vote: "upvote",
-    })
+    await expect(args.onFeedback).toHaveBeenCalledWith(
+      expect.objectContaining({
+        session_id: "workflow-test",
+        kind: "feedback",
+        source: "human",
+        score: 1,
+        metadata: {
+          userId: "user-123",
+          sessionId: "session-456",
+        },
+      })
+    )
 
     // Test 2: Downvote with immediate callback first
     const downvoteButton = canvas.getByText("👎 Dislike")
     await userEvent.click(downvoteButton)
 
-    // Should immediately send feedback (no explanation)
-    await expect(args.onFeedback).toHaveBeenLastCalledWith({
-      session_id: "workflow-test",
-      extra_metadata: {
-        userId: "user-123",
-        sessionId: "session-456",
-      },
-      vote: "downvote",
-    })
+    // Should immediately send feedback (no value)
+    await expect(args.onFeedback).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        session_id: "workflow-test",
+        kind: "feedback",
+        source: "human",
+        score: 0,
+        metadata: {
+          userId: "user-123",
+          sessionId: "session-456",
+        },
+      })
+    )
 
     // Then user can provide detailed feedback
     await userEvent.type(canvas.getByRole("textbox"), "This needs improvement")
 
     await userEvent.click(canvas.getByText("Send"))
 
-    await expect(args.onFeedback).toHaveBeenLastCalledWith({
-      session_id: "workflow-test",
-      extra_metadata: {
-        userId: "user-123",
-        sessionId: "session-456",
-      },
-      vote: "downvote",
-      explanation: "This needs improvement",
-    })
+    await expect(args.onFeedback).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        session_id: "workflow-test",
+        kind: "feedback",
+        source: "human",
+        score: 0,
+        value: "This needs improvement",
+        metadata: {
+          userId: "user-123",
+          sessionId: "session-456",
+        },
+      })
+    )
 
     // Test 3: Downvote without submitting text (should only get initial callback)
     await userEvent.click(downvoteButton)
 
     // This should send feedback immediately
-    await expect(args.onFeedback).toHaveBeenLastCalledWith({
-      session_id: "workflow-test",
-      extra_metadata: {
-        userId: "user-123",
-        sessionId: "session-456",
-      },
-      vote: "downvote",
-    })
+    await expect(args.onFeedback).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        session_id: "workflow-test",
+        kind: "feedback",
+        source: "human",
+        score: 0,
+        metadata: {
+          userId: "user-123",
+          sessionId: "session-456",
+        },
+      })
+    )
 
     // Clicking submit without text should just close (no additional call)
     const callsBefore = [...(args.onFeedback as any).mock.calls]

--- a/src/components/vote-feedback.tsx
+++ b/src/components/vote-feedback.tsx
@@ -77,8 +77,9 @@ interface VoteFeedbackContextValue {
   popoverId: string
   triggerId: string
   session_id: string
-  extra_metadata?: Record<string, any>
+  metadata?: Record<string, any>
   trigger_name?: string
+  trace_id?: string
 }
 
 const VoteFeedbackContext = createContext<VoteFeedbackContextValue | null>(null)
@@ -99,12 +100,14 @@ const VoteFeedbackRoot = ({
   onFeedback,
   defaultText = "",
   session_id: sessionIdProp,
-  extra_metadata,
-  trigger_name,
+  metadata,
+  trigger_name: triggerProp,
+  trace_id,
 }: VoteFeedbackRootProps) => {
   // Resolve session_id (support both string and function)
   const session_id =
     typeof sessionIdProp === "function" ? sessionIdProp() : sessionIdProp
+  const trigger_name = triggerProp || undefined
   const [showPopover, setShowPopover] = useState(false)
   const [feedbackText, setFeedbackText] = useState(defaultText)
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -135,9 +138,12 @@ const VoteFeedbackRoot = ({
     setVote("upvote")
     const data: FeedbackData = {
       session_id,
-      vote: "upvote",
-      ...(extra_metadata && { extra_metadata }),
-      ...(trigger_name && { trigger_name }),
+      kind: "feedback",
+      source: "human",
+      trigger_name,
+      score: 1,
+      ...(metadata && { metadata }),
+      ...(trace_id && { trace_id }),
     }
 
     try {
@@ -146,7 +152,7 @@ const VoteFeedbackRoot = ({
     } finally {
       setIsSubmitting(false)
     }
-  }, [handler, session_id, extra_metadata, trigger_name])
+  }, [handler, session_id, metadata, trigger_name, trace_id])
 
   const handleDownvote = useCallback(async () => {
     setVote("downvote")
@@ -154,9 +160,12 @@ const VoteFeedbackRoot = ({
     if (handler) {
       const data: FeedbackData = {
         session_id,
-        vote: "downvote",
-        ...(extra_metadata && { extra_metadata }),
-        ...(trigger_name && { trigger_name }),
+        kind: "feedback",
+        source: "human",
+        trigger_name,
+        score: 0,
+        ...(metadata && { metadata }),
+        ...(trace_id && { trace_id }),
       }
 
       try {
@@ -182,7 +191,7 @@ const VoteFeedbackRoot = ({
       document.body.appendChild(announcement)
       setTimeout(() => document.body.removeChild(announcement), 1000)
     }, 0)
-  }, [handler, session_id, extra_metadata, trigger_name])
+  }, [handler, session_id, metadata, trigger_name, trace_id])
 
   const handleTextareaChange = useCallback(
     (e: React.ChangeEvent<HTMLTextAreaElement>) => {
@@ -195,13 +204,16 @@ const VoteFeedbackRoot = ({
     const hasText = feedbackText.trim().length > 0
 
     if (hasText) {
-      // Submit with explanation
+      // Submit with value (explanation text)
       const data: FeedbackData = {
         session_id,
-        vote: "downvote",
-        explanation: feedbackText,
-        ...(extra_metadata && { extra_metadata }),
-        ...(trigger_name && { trigger_name }),
+        kind: "feedback",
+        source: "human",
+        trigger_name,
+        score: 0,
+        value: feedbackText,
+        ...(metadata && { metadata }),
+        ...(trace_id && { trace_id }),
       }
 
       try {
@@ -232,8 +244,9 @@ const VoteFeedbackRoot = ({
     feedbackText,
     defaultText,
     session_id,
-    extra_metadata,
+    metadata,
     trigger_name,
+    trace_id,
   ])
 
   const handleKeyDown = useCallback(
@@ -289,8 +302,9 @@ const VoteFeedbackRoot = ({
     popoverId,
     triggerId,
     session_id,
-    extra_metadata,
+    metadata,
     trigger_name,
+    trace_id,
   }
 
   return (

--- a/src/contexts/kelet.stories.tsx
+++ b/src/contexts/kelet.stories.tsx
@@ -79,8 +79,11 @@ function YourComponent() {
   const handleFeedback = async () => {
     await feedback({
       session_id: 'unique-id',
-      vote: 'upvote',
-      explanation: 'Great feature!'
+      kind: 'feedback',
+      source: 'human',
+      trigger_name: 'thumbs',
+      score: 1,
+      value: 'Great feature!'
     });
   };
   
@@ -145,7 +148,10 @@ function ReusableButton() {
     // Works with or without provider - no-op if no provider
     await feedback({
       session_id: 'button-click',
-      vote: 'upvote'
+      kind: 'feedback',
+      source: 'human',
+      trigger_name: 'thumbs',
+      score: 1
     });
   };
   
@@ -169,7 +175,7 @@ The provider automatically handles common scenarios:
 
 \`\`\`tsx
 try {
-  await feedback({ session_id: 'test', vote: 'upvote' });
+  await feedback({ session_id: 'test', kind: 'feedback', source: 'human', trigger_name: 'thumbs', score: 1 });
 } catch (error) {
   console.error('Feedback failed:', error.message);
   // Handle error appropriately
@@ -246,8 +252,11 @@ export const BasicProvider: Story = {
         try {
           await feedback({
             session_id: `demo-${Date.now()}`,
-            vote: "upvote",
-            explanation: feedbackText || undefined,
+            kind: "feedback",
+            source: "human",
+            trigger_name: "thumbs",
+            score: 1,
+            value: feedbackText || undefined,
           })
           setFeedbackText("")
         } catch (_error) {
@@ -354,13 +363,16 @@ This is useful when you have:
       const { api_key, project, feedback } = useKelet()
       const [status, setStatus] = useState("")
 
-      const handleFeedback = async (vote: "upvote" | "downvote") => {
+      const handleFeedback = async (score: number) => {
         setStatus("Submitting...")
         try {
           await feedback({
             session_id: `${project}-demo-${Date.now()}`,
-            vote,
-            explanation: `Feedback for ${project} project`,
+            kind: "feedback",
+            source: "human",
+            trigger_name: "thumbs",
+            score,
+            value: `Feedback for ${project} project`,
           })
           setStatus(`✓ Submitted to ${project}`)
           setTimeout(() => setStatus(""), 2000)
@@ -401,7 +413,7 @@ This is useful when you have:
             <button
               data-testid={`${testId}-upvote`}
               data-feedback-id={`${testId}-upvote`}
-              onClick={() => handleFeedback("upvote")}
+              onClick={() => handleFeedback(1)}
               style={{
                 backgroundColor: "rgba(255,255,255,0.2)",
                 border: "1px solid rgba(255,255,255,0.3)",
@@ -417,7 +429,7 @@ This is useful when you have:
             <button
               data-testid={`${testId}-downvote`}
               data-feedback-id={`${testId}-downvote`}
-              onClick={() => handleFeedback("downvote")}
+              onClick={() => handleFeedback(0)}
               style={{
                 backgroundColor: "rgba(255,255,255,0.2)",
                 border: "1px solid rgba(255,255,255,0.3)",
@@ -569,7 +581,10 @@ Key behaviors:
           // This will be mocked to fail in the test
           await feedback({
             session_id: "error-test",
-            vote: "upvote",
+            kind: "feedback",
+            source: "human",
+            trigger_name: "thumbs",
+            score: 1,
           })
           setStatus("Success (unexpected!)")
         } catch (_error) {
@@ -628,7 +643,10 @@ Key behaviors:
           // This should work silently (no-op when no provider)
           await defaultHandler({
             session_id: "no-provider-test",
-            vote: "upvote",
+            kind: "feedback",
+            source: "human",
+            trigger_name: "thumbs",
+            score: 1,
           })
           setStatus("Default handler worked (no-op)")
         } catch (_error) {
@@ -780,14 +798,17 @@ Shows:
       const { api_key, project, feedback } = useKelet()
       const [lastSubmission, setLastSubmission] = useState("")
 
-      const handleQuickFeedback = async (vote: "upvote" | "downvote") => {
+      const handleQuickFeedback = async (score: number) => {
         try {
           await feedback({
             session_id: `quick-${Date.now()}`,
-            vote,
-            explanation: `Quick ${vote} from useKelet hook`,
+            kind: "feedback",
+            source: "human",
+            trigger_name: "thumbs",
+            score,
+            value: `Quick ${score === 1 ? "upvote" : "downvote"} from useKelet hook`,
           })
-          setLastSubmission(`${vote} submitted to ${project}`)
+          setLastSubmission(`${score === 1 ? "upvote" : "downvote"} submitted to ${project}`)
         } catch (_error) {
           setLastSubmission("Error: " + (_error as Error).message)
         }
@@ -822,7 +843,7 @@ Shows:
             <button
               data-testid="use-kelet-upvote"
               data-feedback-id="use-kelet-upvote"
-              onClick={() => handleQuickFeedback("upvote")}
+              onClick={() => handleQuickFeedback(1)}
               style={{
                 backgroundColor: "#48bb78",
                 color: "white",
@@ -838,7 +859,7 @@ Shows:
             <button
               data-testid="use-kelet-downvote"
               data-feedback-id="use-kelet-downvote"
-              onClick={() => handleQuickFeedback("downvote")}
+              onClick={() => handleQuickFeedback(0)}
               style={{
                 backgroundColor: "#e53e3e",
                 color: "white",
@@ -877,8 +898,11 @@ Shows:
         try {
           await feedbackHandler({
             session_id: `default-handler-${Date.now()}`,
-            vote: "upvote",
-            explanation: "Using default feedback handler",
+            kind: "feedback",
+            source: "human",
+            trigger_name: "thumbs",
+            score: 1,
+            value: "Using default feedback handler",
           })
           setStatus("✓ Submitted successfully")
           setTimeout(() => setStatus(""), 2000)

--- a/src/contexts/kelet.test.tsx
+++ b/src/contexts/kelet.test.tsx
@@ -64,8 +64,11 @@ describe("KeletProvider", () => {
 
       await result.current.feedback({
         session_id: "test-id",
-        vote: "upvote",
-        explanation: "Great feature!",
+        kind: "feedback",
+        source: "human",
+        trigger_name: "thumbs",
+        score: 1,
+        value: "Great feature!",
       })
 
       expect(mockFetch).toHaveBeenCalledWith(
@@ -76,14 +79,17 @@ describe("KeletProvider", () => {
             "Content-Type": "application/json",
             Authorization: "Bearer test-api-key",
           },
-          body: JSON.stringify({
-            session_id: "test-id",
-            source: "EXPLICIT",
-            vote: "upvote",
-            explanation: "Great feature!",
-          }),
         })
       )
+
+      const body = JSON.parse(mockFetch.mock.calls[0]![1]!.body)
+      expect(body.session_id).toBe("test-id")
+      expect(body.kind).toBe("feedback")
+      expect(body.source).toBe("human")
+      expect(body.trigger_name).toBe("thumbs")
+      expect(body.score).toBe(1)
+      expect(body.value).toBe("Great feature!")
+      expect(body.timestamp).toBeDefined()
     })
 
     it("should handle API errors gracefully", async () => {
@@ -103,7 +109,10 @@ describe("KeletProvider", () => {
       await expect(
         result.current.feedback({
           session_id: "test-id",
-          vote: "upvote",
+          kind: "feedback",
+          source: "human",
+          trigger_name: "thumbs",
+          score: 1,
         })
       ).rejects.toThrow("Failed to submit feedback: Unauthorized")
     })
@@ -137,7 +146,10 @@ describe("KeletProvider", () => {
 
       await result.current.feedback({
         session_id: "nested-test",
-        vote: "downvote",
+        kind: "feedback",
+        source: "human",
+        trigger_name: "thumbs",
+        score: 0,
       })
 
       expect(mockFetch).toHaveBeenCalledWith(
@@ -203,11 +215,13 @@ describe("KeletProvider", () => {
     it("should include all feedback properties in API call", async () => {
       const feedbackData: FeedbackData = {
         session_id: "complex-test",
-        vote: "downvote",
-        explanation: "Could be better",
-        correction: "Try this instead",
-        selection: "selected text",
-        source: "IMPLICIT",
+        kind: "edit",
+        source: "human",
+        trigger_name: "auto_state_change",
+        score: 0,
+        value: "Try this instead",
+        confidence: 0.75,
+        metadata: { selection: "selected text" },
       }
 
       const wrapper = ({ children }: { children: React.ReactNode }) => (
@@ -220,22 +234,19 @@ describe("KeletProvider", () => {
 
       await result.current.feedback(feedbackData)
 
-      expect(mockFetch).toHaveBeenCalledWith(
-        "https://api.kelet.ai/api/projects/test/signal",
-        expect.objectContaining({
-          body: JSON.stringify({
-            session_id: "complex-test",
-            source: "IMPLICIT",
-            vote: "downvote",
-            explanation: "Could be better",
-            correction: "Try this instead",
-            selection: "selected text",
-          }),
-        })
-      )
+      const body = JSON.parse(mockFetch.mock.calls[0]![1]!.body)
+      expect(body.session_id).toBe("complex-test")
+      expect(body.kind).toBe("edit")
+      expect(body.source).toBe("human")
+      expect(body.trigger_name).toBe("auto_state_change")
+      expect(body.score).toBe(0)
+      expect(body.value).toBe("Try this instead")
+      expect(body.confidence).toBe(0.75)
+      expect(body.metadata.selection).toBe("selected text")
+      expect(body.timestamp).toBeDefined()
     })
 
-    it("should default source to EXPLICIT when not provided", async () => {
+    it("should add timestamp automatically when not provided", async () => {
       const wrapper = ({ children }: { children: React.ReactNode }) => (
         <KeletProvider apiKey="test-key" project="test">
           {children}
@@ -245,20 +256,17 @@ describe("KeletProvider", () => {
       const { result } = renderHook(() => useKelet(), { wrapper })
 
       await result.current.feedback({
-        session_id: "default-source-test",
-        vote: "upvote",
+        session_id: "timestamp-test",
+        kind: "feedback",
+        source: "human",
+        trigger_name: "thumbs",
+        score: 1,
       })
 
-      expect(mockFetch).toHaveBeenCalledWith(
-        expect.any(String),
-        expect.objectContaining({
-          body: JSON.stringify({
-            session_id: "default-source-test",
-            source: "EXPLICIT",
-            vote: "upvote",
-          }),
-        })
-      )
+      const body = JSON.parse(mockFetch.mock.calls[0]![1]!.body)
+      expect(body.timestamp).toBeDefined()
+      // Verify it's a valid ISO 8601 string
+      expect(new Date(body.timestamp).toISOString()).toBe(body.timestamp)
     })
   })
 })
@@ -307,7 +315,10 @@ describe("useDefaultFeedbackHandler hook", () => {
     await expect(
       result.current({
         session_id: "test",
-        vote: "upvote",
+        kind: "feedback",
+        source: "human",
+        trigger_name: "thumbs",
+        score: 1,
       })
     ).resolves.not.toThrow()
 
@@ -342,20 +353,19 @@ describe("useDefaultFeedbackHandler hook", () => {
 
     await result.current({
       session_id: "default-handler-test",
-      vote: "upvote",
-      explanation: "Using default handler",
+      kind: "feedback",
+      source: "human",
+      trigger_name: "thumbs",
+      score: 1,
+      value: "Using default handler",
     })
 
-    expect(mockFetch).toHaveBeenCalledWith(
-      "https://api.kelet.ai/api/projects/test-project/signal",
-      expect.objectContaining({
-        body: JSON.stringify({
-          session_id: "default-handler-test",
-          source: "EXPLICIT",
-          vote: "upvote",
-          explanation: "Using default handler",
-        }),
-      })
-    )
+    const body = JSON.parse(mockFetch.mock.calls[0]![1]!.body)
+    expect(body.session_id).toBe("default-handler-test")
+    expect(body.kind).toBe("feedback")
+    expect(body.source).toBe("human")
+    expect(body.trigger_name).toBe("thumbs")
+    expect(body.score).toBe(1)
+    expect(body.value).toBe("Using default handler")
   })
 })

--- a/src/contexts/kelet.tsx
+++ b/src/contexts/kelet.tsx
@@ -17,13 +17,15 @@ interface KeletProviderProps {
 
 interface FeedbackRequest {
   session_id: string
-  source: "IMPLICIT" | "EXPLICIT"
+  kind: "feedback" | "edit"
+  source: "human"
   trigger_name?: string
-  vote: "upvote" | "downvote"
-  explanation?: string
-  selection?: string
-  correction?: string
+  score?: number
+  value?: string
+  confidence?: number
   metadata?: Record<string, any>
+  timestamp?: string
+  trace_id?: string
 }
 
 // Create the context
@@ -94,19 +96,21 @@ export const KeletProvider: React.FC<
 
     // Merge captured event into metadata
     const metadata = {
-      ...(data.extra_metadata ?? {}),
+      ...(data.metadata ?? {}),
       ...(capturedEvent && { $dom_event: capturedEvent }),
     }
 
     const req: FeedbackRequest = {
       session_id: data.session_id,
-      source: data.source || "EXPLICIT",
-      vote: data.vote,
-      explanation: data.explanation,
-      correction: data.correction,
-      selection: data.selection,
+      kind: data.kind,
+      source: data.source,
       trigger_name: data.trigger_name,
+      score: data.score,
+      value: data.value,
+      confidence: data.confidence,
       metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
+      timestamp: data.timestamp || new Date().toISOString(),
+      trace_id: data.trace_id,
     }
     const response = await fetch(url, {
       method: "POST",

--- a/src/hooks/feedback-state/types.ts
+++ b/src/hooks/feedback-state/types.ts
@@ -13,7 +13,7 @@ export interface FeedbackStateOptions<T> {
   debounceMs?: number
 
   /**
-   * Format for the diff output in the correction field
+   * Format for the diff output in the value field
    * @default 'git'
    */
   diffType?: DiffType
@@ -34,16 +34,15 @@ export interface FeedbackStateOptions<T> {
   onFeedback?: FeedbackHandler
 
   /**
-   * Vote classification - static vote or function to determine vote based on changes
-   * @default Automatic determination based on diff percentage (>50% = downvote, ≤50% = upvote)
+   * Score classification - static score or function to determine score based on changes
+   * @default Automatic determination based on diff percentage (>50% = 0, ≤50% = 1)
    */
-  vote?:
-    | "upvote"
-    | "downvote"
-    | ((before: T, after: T, diffPercentage: number) => "upvote" | "downvote")
+  score?:
+    | number
+    | ((before: T, after: T, diffPercentage: number) => number)
 
   /**
-   * Default trigger name for state changes when no trigger_name is specified in setState/dispatch
+   * Default trigger name for state changes when no trigger is specified in setState/dispatch
    * @default 'auto_state_change'
    */
   default_trigger_name?: string

--- a/src/hooks/feedback-state/use-feedback-reducer.stories.tsx
+++ b/src/hooks/feedback-state/use-feedback-reducer.stories.tsx
@@ -378,10 +378,10 @@ interface FeedbackStateOptions<T> {
 
 ## Integration:
 - Uses existing Kelet context for feedback submission
-- Sends feedback with \`source: 'IMPLICIT'\`
-- Includes diff data in the \`correction\` field
-- Major changes (>50% different) are sent as downvotes
-- Minor changes (≤50% different) are sent as upvotes
+- Sends feedback with \`kind: 'edit'\` and \`source: 'human'\`
+- Includes diff data in the \`value\` field
+- \`confidence\` field contains the diff percentage
+- \`score\` is determined by change size: >50% different → 0, ≤50% → 1
 - Automatically extracts trigger names from \`action.type\`
 
 Perfect for automatically capturing user interactions as implicit feedback in reducer-based components!
@@ -472,10 +472,11 @@ Try clicking the buttons and watch the console for feedback logs with extracted 
     // Get the actual call and verify the essential properties
     const feedbackCall = (args.onFeedback as any)?.mock?.calls?.[0]?.[0]
     await expect(feedbackCall.session_id).toBe("counter-demo")
-    await expect(feedbackCall.source).toBe("IMPLICIT")
+    await expect(feedbackCall.kind).toBe("edit")
+    await expect(feedbackCall.source).toBe("human")
     await expect(feedbackCall.trigger_name).toBe("increment") // Extracted from action.type
-    await expect(feedbackCall.correction).toBeTruthy()
-    await expect(feedbackCall.explanation).toContain("diff percentage")
+    await expect(feedbackCall.value).toBeTruthy()
+    await expect(feedbackCall.confidence).toBeDefined()
 
     // Test another action type
     const addButton = canvas.getByText("Add 5")
@@ -654,9 +655,9 @@ This test simulates rapid user interactions and verifies that only ONE feedback 
     const feedbackCall = (args.onFeedback as any)?.mock?.calls?.[0]?.[0]
     await expect(feedbackCall.trigger_name).toBe("increment")
 
-    // The correction should show the change from 0 to 4 (not individual steps)
-    await expect(feedbackCall.correction).toContain('"count": 0')
-    await expect(feedbackCall.correction).toContain('"count": 4')
+    // The value should show the change from 0 to 4 (not individual steps)
+    await expect(feedbackCall.value).toContain('"count": 0')
+    await expect(feedbackCall.value).toContain('"count": 4')
   },
 }
 

--- a/src/hooks/feedback-state/use-feedback-state.stories.tsx
+++ b/src/hooks/feedback-state/use-feedback-state.stories.tsx
@@ -315,10 +315,10 @@ interface FeedbackStateOptions<T> {
 
 ## Integration:
 - Uses existing Kelet context for feedback submission
-- Sends feedback with \`source: 'IMPLICIT'\`
-- Includes diff data in the \`correction\` field
-- Major changes (>50% different) are sent as downvotes
-- Minor changes (≤50% different) are sent as upvotes
+- Sends feedback with \`kind: 'edit'\` and \`source: 'human'\`
+- Includes diff data in the \`value\` field
+- \`confidence\` field contains the diff percentage
+- \`score\` is determined by change size: >50% different → 0, ≤50% → 1
 
 Perfect for automatically capturing user state changes as implicit feedback!
         `,
@@ -399,10 +399,11 @@ Try clicking the buttons and watch the console for feedback logs!
     // Get the actual call and verify the essential properties
     const feedbackCall = (args.onFeedback as any)?.mock?.calls?.[0]?.[0]
     await expect(feedbackCall.session_id).toBe("counter-demo")
-    await expect(feedbackCall.source).toBe("IMPLICIT")
-    await expect(feedbackCall.vote).toBe("downvote")
-    await expect(feedbackCall.correction).toBeTruthy()
-    await expect(feedbackCall.explanation).toContain("diff percentage")
+    await expect(feedbackCall.kind).toBe("edit")
+    await expect(feedbackCall.source).toBe("human")
+    await expect(feedbackCall.score).toBeDefined()
+    await expect(feedbackCall.value).toBeTruthy()
+    await expect(feedbackCall.confidence).toBeDefined()
 
     // Test function update
     const doubleButton = canvas.getByText("Double (Function Update)")
@@ -547,11 +548,12 @@ Use the text input to set custom values like \`"hello"\`, \`123\`, or \`{"custom
     // Get the actual call and verify the essential properties
     const feedbackCall = (args.onFeedback as any)?.mock?.calls?.[0]?.[0]
     await expect(feedbackCall.session_id).toBe("custom-demo")
-    await expect(feedbackCall.source).toBe("IMPLICIT")
-    await expect(feedbackCall.vote).toBe("upvote") // Fixed: object change is now calculated as <50%
-    await expect(feedbackCall.correction).toBeTruthy()
-    await expect(feedbackCall.explanation).toContain("diff percentage")
-    await expect(feedbackCall.extra_metadata.test).toBe(true)
+    await expect(feedbackCall.kind).toBe("edit")
+    await expect(feedbackCall.source).toBe("human")
+    await expect(feedbackCall.score).toBeDefined()
+    await expect(feedbackCall.value).toBeTruthy()
+    await expect(feedbackCall.confidence).toBeDefined()
+    await expect(feedbackCall.metadata.test).toBe(true)
 
     // Clear and set a number
     await userEvent.clear(customInput)
@@ -624,11 +626,12 @@ This test simulates rapid user interactions and verifies that only ONE feedback 
 
     const feedbackCall = (args.onFeedback as any)?.mock?.calls?.[0]?.[0]
     await expect(feedbackCall.session_id).toBe("rapid-changes-demo")
-    await expect(feedbackCall.source).toBe("IMPLICIT")
+    await expect(feedbackCall.kind).toBe("edit")
+    await expect(feedbackCall.source).toBe("human")
 
-    // The correction should show the change from 0 to 4 (not individual steps)
-    await expect(feedbackCall.correction).toContain("-0")
-    await expect(feedbackCall.correction).toContain("+4")
+    // The value should show the change from 0 to 4 (not individual steps)
+    await expect(feedbackCall.value).toContain("-0")
+    await expect(feedbackCall.value).toContain("+4")
   },
 }
 
@@ -638,10 +641,10 @@ export const CustomVoteLogic: Story = {
     session_id: "issue-tracker",
     options: {
       debounceMs: 300,
-      vote: (before: any, after: any, _diffPercentage: number) => {
-        // Custom logic: upvote if priority increased, downvote if decreased
-        if (after.priority > before.priority) return "upvote"
-        if (after.priority < before.priority) return "downvote"
+      score: (before: any, after: any, _diffPercentage: number) => {
+        // Custom logic: score 1 if priority increased, score 0 if decreased
+        if (after.priority > before.priority) return 1
+        if (after.priority < before.priority) return 0
 
         // For same priority, use severity logic
         const severityOrder = { low: 1, medium: 2, high: 3, critical: 4 }
@@ -650,7 +653,7 @@ export const CustomVoteLogic: Story = {
         const afterSev =
           severityOrder[after.severity as keyof typeof severityOrder] || 1
 
-        return afterSev > beforeSev ? "downvote" : "upvote" // Higher severity = downvote
+        return afterSev > beforeSev ? 0 : 1 // Higher severity = score 0
       },
     },
   },
@@ -658,18 +661,18 @@ export const CustomVoteLogic: Story = {
     docs: {
       description: {
         story: `
-**Custom Vote Logic** - Demonstrates custom vote determination based on business logic.
+**Custom Score Logic** - Demonstrates custom score determination based on business logic.
 
 **Features:**
-- Custom vote function with access to before/after states and diff percentage
-- Business-specific logic (priority increase = upvote, severity increase = downvote)
+- Custom score function with access to before/after states and diff percentage
+- Business-specific logic (priority increase = score 1, severity increase = score 0)
 - Demonstrates real-world scenario for issue tracking systems
 
-**Vote Logic:**
-- Priority increased: upvote (good change)
-- Priority decreased: downvote (regression) 
-- Higher severity: downvote (problem got worse)
-- Lower severity: upvote (problem got better)
+**Score Logic:**
+- Priority increased: score 1 (good change)
+- Priority decreased: score 0 (regression)
+- Higher severity: score 0 (problem got worse)
+- Lower severity: score 1 (problem got better)
         `,
       },
     },
@@ -690,10 +693,11 @@ export const CustomVoteLogic: Story = {
 
     const feedbackCall = (args.onFeedback as any)?.mock?.calls?.[0]?.[0]
     await expect(feedbackCall.session_id).toBe("issue-tracker")
-    await expect(feedbackCall.source).toBe("IMPLICIT")
+    await expect(feedbackCall.kind).toBe("edit")
+    await expect(feedbackCall.source).toBe("human")
 
-    // The custom vote logic should determine the vote, not the default percentage logic
-    await expect(feedbackCall.vote).toBeDefined()
+    // The custom score logic should determine the score, not the default percentage logic
+    await expect(feedbackCall.score).toBeDefined()
   },
 }
 
@@ -703,17 +707,17 @@ export const StaticVoteConfiguration: Story = {
     session_id: "content-editor",
     options: {
       debounceMs: 300,
-      vote: "upvote", // Always upvote regardless of changes
+      score: 1, // Always score 1 regardless of changes
     },
   },
   parameters: {
     docs: {
       description: {
         story: `
-**Static Vote Configuration** - Always sends the same vote type.
+**Static Score Configuration** - Always sends the same score.
 
 **Features:**
-- Static vote setting overrides automatic determination
+- Static score setting overrides automatic determination
 - Useful for scenarios where all changes are considered positive/negative
 - Example: Content editing where any engagement is positive
 
@@ -737,7 +741,7 @@ export const StaticVoteConfiguration: Story = {
     await expect(args.onFeedback).toHaveBeenCalledTimes(1)
 
     const feedbackCall = (args.onFeedback as any)?.mock?.calls?.[0]?.[0]
-    await expect(feedbackCall.vote).toBe("upvote") // Should always be upvote
+    await expect(feedbackCall.score).toBe(1) // Should always be score 1
 
     // Make another change (completely different content)
     const prefixButton = canvas.getByText('Prefix with "Updated"')
@@ -749,7 +753,7 @@ export const StaticVoteConfiguration: Story = {
     // Still upvote despite major change
     await expect(args.onFeedback).toHaveBeenCalledTimes(2)
     const secondCall = (args.onFeedback as any)?.mock?.calls?.[1]?.[0]
-    await expect(secondCall.vote).toBe("upvote") // Still upvote
+    await expect(secondCall.score).toBe(1) // Still score 1
   },
 }
 
@@ -965,7 +969,8 @@ This prevents noise from the common \`useState(null)\` → API load → \`setSta
 
     const feedbackCall = (args.onFeedback as any)?.mock?.calls?.[0]?.[0]
     await expect(feedbackCall.session_id).toBe("user-data-with-ignore")
-    await expect(feedbackCall.source).toBe("IMPLICIT")
+    await expect(feedbackCall.kind).toBe("edit")
+    await expect(feedbackCall.source).toBe("human")
   },
 }
 

--- a/src/hooks/feedback-state/use-feedback-state.test.ts
+++ b/src/hooks/feedback-state/use-feedback-state.test.ts
@@ -57,8 +57,8 @@ describe("useFeedbackState - Diff utilities", () => {
   })
 })
 
-// Tests for trigger_name functionality
-describe("useFeedbackState - trigger_name functionality", () => {
+// Tests for trigger functionality
+describe("useFeedbackState - trigger functionality", () => {
   beforeEach(() => {
     vi.useFakeTimers()
   })
@@ -68,7 +68,7 @@ describe("useFeedbackState - trigger_name functionality", () => {
     vi.useRealTimers()
   })
 
-  it("uses default trigger_name when no default_trigger_name is specified", async () => {
+  it("uses default trigger when no default_trigger_name is specified", async () => {
     const mockHandler = vi.fn()
     const { result } = renderHook(() =>
       useFeedbackState("initial", "test-id", {
@@ -89,6 +89,8 @@ describe("useFeedbackState - trigger_name functionality", () => {
       expect.objectContaining({
         trigger_name: "auto_state_change",
         session_id: "test-id",
+        kind: "edit",
+        source: "human",
       })
     )
   })
@@ -118,7 +120,7 @@ describe("useFeedbackState - trigger_name functionality", () => {
     )
   })
 
-  it("overrides default with setState trigger_name parameter", async () => {
+  it("overrides default with setState trigger parameter", async () => {
     const mockHandler = vi.fn()
     const { result } = renderHook(() =>
       useFeedbackState("initial", "test-id", {
@@ -331,6 +333,33 @@ describe("useFeedbackState - trigger_name functionality", () => {
       })
     )
   })
+
+  it("emits kind=edit and source=human for state changes", async () => {
+    const mockHandler = vi.fn()
+    const { result } = renderHook(() =>
+      useFeedbackState("initial", "test-id", {
+        debounceMs: 500,
+        onFeedback: mockHandler,
+      })
+    )
+
+    act(() => {
+      result.current[1]("changed")
+    })
+
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+
+    expect(mockHandler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "edit",
+        source: "human",
+        confidence: expect.any(Number),
+        value: expect.any(String),
+      })
+    )
+  })
 })
 
 // Tests for ignoreInitialNullish functionality
@@ -423,6 +452,8 @@ describe("useFeedbackState - ignoreInitialNullish functionality", () => {
       expect.objectContaining({
         session_id: "api-data-session",
         trigger_name: "auto_state_change",
+        kind: "edit",
+        source: "human",
       })
     )
   })
@@ -591,9 +622,9 @@ describe("useFeedbackState - baseline diffing", () => {
 
     expect(mockHandler).toHaveBeenCalledTimes(1)
     const call = mockHandler.mock.calls[0]?.[0]
-    const correction = JSON.parse(call.correction)
-    expect(correction.before).toBe("a")
-    expect(correction.after).toBe("abc")
+    const value = JSON.parse(call.value)
+    expect(value.before).toBe("a")
+    expect(value.after).toBe("abc")
   })
 
   it("when initial is nullish and ignored, baseline becomes first non-nullish value", async () => {
@@ -626,8 +657,8 @@ describe("useFeedbackState - baseline diffing", () => {
 
     expect(mockHandler).toHaveBeenCalledTimes(1)
     const call = mockHandler.mock.calls[0]?.[0]
-    const correction = JSON.parse(call.correction)
-    expect(correction.before).toBe("first")
-    expect(correction.after).toBe("second")
+    const value = JSON.parse(call.value)
+    expect(value.before).toBe("first")
+    expect(value.after).toBe("second")
   })
 })

--- a/src/hooks/feedback-state/use-state-change-tracking.ts
+++ b/src/hooks/feedback-state/use-state-change-tracking.ts
@@ -63,15 +63,15 @@ export function useStateChangeTracking<T>(
       const diffPercentage = calculateDiffPercentage(startState, endState)
       const diffString = formatDiff(startState, endState, diffType)
 
-      let vote: "upvote" | "downvote"
-      if (options?.vote) {
-        if (typeof options.vote === "function") {
-          vote = options.vote(startState, endState, diffPercentage)
+      let score: number
+      if (options?.score != null) {
+        if (typeof options.score === "function") {
+          score = options.score(startState, endState, diffPercentage)
         } else {
-          vote = options.vote
+          score = options.score
         }
       } else {
-        vote = diffPercentage > 0.5 ? "downvote" : "upvote"
+        score = diffPercentage > 0.5 ? 0 : 1
       }
 
       const idString =
@@ -79,12 +79,13 @@ export function useStateChangeTracking<T>(
 
       feedbackHandler({
         session_id: idString,
-        vote,
-        explanation: `State change with diff percentage: ${(diffPercentage * 100).toFixed(1)}%`,
-        correction: diffString,
-        source: "IMPLICIT",
-        extra_metadata: options?.metadata,
+        kind: "edit",
+        source: "human",
         trigger_name: triggerName,
+        score,
+        value: diffString,
+        confidence: diffPercentage,
+        metadata: options?.metadata,
       })
     },
     [options, session_id, diffType, feedbackHandler]

--- a/src/hooks/feedback-state/use-state-change-tracking.ts
+++ b/src/hooks/feedback-state/use-state-change-tracking.ts
@@ -63,16 +63,10 @@ export function useStateChangeTracking<T>(
       const diffPercentage = calculateDiffPercentage(startState, endState)
       const diffString = formatDiff(startState, endState, diffType)
 
-      let score: number
-      if (options?.score != null) {
-        if (typeof options.score === "function") {
-          score = options.score(startState, endState, diffPercentage)
-        } else {
-          score = options.score
-        }
-      } else {
-        score = diffPercentage > 0.5 ? 0 : 1
-      }
+      const score =
+        typeof options?.score === "function"
+          ? options.score(startState, endState, diffPercentage)
+          : (options?.score ?? (diffPercentage > 0.5 ? 0 : 1))
 
       const idString =
         typeof session_id === "function" ? session_id(endState) : session_id

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -24,17 +24,24 @@ export interface CapturedEvent {
 }
 
 /**
+ * Signal kind — what type of signal this is
+ */
+export type SignalKind = "feedback" | "edit"
+
+/**
  * Feedback data structure returned by the component
  */
 export interface FeedbackData {
   session_id: string
-  extra_metadata?: Record<string, any>
-  vote: "upvote" | "downvote"
-  explanation?: string
-  source?: "IMPLICIT" | "EXPLICIT" // Default is 'EXPLICIT'
-  correction?: string // Used for diff data
-  selection?: string // Optional selected text
-  trigger_name?: string // Optional trigger name for categorizing feedback
+  kind: SignalKind
+  source: "human"
+  trigger_name?: string
+  score?: number // 1 for upvote, 0 for downvote
+  value?: string // text content: feedback text, diff, reasoning, etc.
+  confidence?: number // diff_percentage for implicit edits (0.0-1.0)
+  metadata?: Record<string, any>
+  timestamp?: string // ISO 8601
+  trace_id?: string // optional, if available
 }
 
 /**
@@ -46,8 +53,9 @@ export interface VoteFeedbackRootProps {
   onFeedback?: (data: FeedbackData) => void | Promise<void>
   defaultText?: string
   session_id: string | (() => string)
-  extra_metadata?: Record<string, any>
-  trigger_name?: string // Optional trigger name for categorizing feedback
+  metadata?: Record<string, any>
+  trigger_name?: string // Trigger name for categorizing feedback (no default)
+  trace_id?: string // Optional trace ID to attach to feedback
 }
 
 /**

--- a/src/ui/shadcn/vote-feedback.stories.tsx
+++ b/src/ui/shadcn/vote-feedback.stories.tsx
@@ -85,7 +85,7 @@ Perfect for professional applications with clean, modern UI.
       control: "text",
       description: "Required session ID for tracking feedback",
     },
-    extra_metadata: {
+    metadata: {
       control: "object",
       description: "Optional metadata to include with feedback",
     },
@@ -162,10 +162,14 @@ Professional and clean!
     // Assert upvote is selected (data-selected) and downvote is not
     await expect(upvoteButton).toHaveAttribute("data-selected", "true")
     await expect(downvoteButton).toHaveAttribute("data-selected", "false")
-    await expect(args.onFeedback).toHaveBeenCalledWith({
-      session_id: "shadcn-default",
-      vote: "upvote",
-    })
+    await expect(args.onFeedback).toHaveBeenCalledWith(
+      expect.objectContaining({
+        session_id: "shadcn-default",
+        kind: "feedback",
+        source: "human",
+        score: 1,
+      })
+    )
 
     // 3. Click downvote
     await userEvent.click(downvoteButton)
@@ -173,10 +177,14 @@ Professional and clean!
     // Assert downvote is selected and upvote is not
     await expect(downvoteButton).toHaveAttribute("data-selected", "true")
     await expect(upvoteButton).toHaveAttribute("data-selected", "false")
-    await expect(args.onFeedback).toHaveBeenLastCalledWith({
-      session_id: "shadcn-default",
-      vote: "downvote",
-    })
+    await expect(args.onFeedback).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        session_id: "shadcn-default",
+        kind: "feedback",
+        source: "human",
+        score: 0,
+      })
+    )
 
     // 4. Add detailed feedback
     const textarea = await within(document.body).findByPlaceholderText(
@@ -187,11 +195,15 @@ Professional and clean!
     const submitButton = within(document.body).getByText("Submit")
     await userEvent.click(submitButton)
 
-    await expect(args.onFeedback).toHaveBeenLastCalledWith({
-      session_id: "shadcn-default",
-      vote: "downvote",
-      explanation: "The explanation could be clearer",
-    })
+    await expect(args.onFeedback).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        session_id: "shadcn-default",
+        kind: "feedback",
+        source: "human",
+        score: 0,
+        value: "The explanation could be clearer",
+      })
+    )
   },
 }
 


### PR DESCRIPTION
# User description
fixes KEL-294

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Refactors the feedback system to replace the binary vote model with a score-based feedback model, introducing <code>kind</code>, <code>score</code>, and <code>value</code> fields to the core <code>FeedbackData</code> interface. Updates the API to process these new signal types and modifies all associated UI components and state-tracking hooks to emit feedback conforming to this more granular structure.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/Kelet-ai/feedback-ui/6?tool=ast&topic=Core+Data+Model+%26+API>Core Data Model & API</a>
        </td><td>Redefine the fundamental feedback data structure by replacing the binary <code>vote</code> field with a numeric <code>score</code> and introducing <code>kind</code> (e.g., 'feedback', 'edit'), <code>source</code> (fixed to 'human'), <code>value</code> (for text content like explanations or diffs), <code>confidence</code>, <code>timestamp</code>, and <code>trace_id</code> fields. This also involves updating the internal API request structure and ensuring automatic timestamp generation.<details><summary>Modified files (3)</summary><ul><li>src/contexts/kelet.test.tsx</li>
<li>src/contexts/kelet.tsx</li>
<li>src/types/index.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>almog.baku@gmail.com</td><td>chore-stricter-prettier</td><td>February 22, 2026</td></tr>
<tr><td>ilanbenb</td><td>Bug-fix-double-error</td><td>August 20, 2025</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/Kelet-ai/feedback-ui/6?tool=ast&topic=Other>Other</a>
        </td><td>Other files<details><summary>Modified files (1)</summary><ul><li>src/contexts/kelet.stories.tsx</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>almog.baku@gmail.com</td><td>chore-stricter-prettier</td><td>February 22, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/Kelet-ai/feedback-ui/6?tool=ast&topic=UI+Components+%26+Hooks>UI Components & Hooks</a>
        </td><td>Update the <code>VoteFeedback</code> UI components and the <code>useFeedbackState</code> and <code>useFeedbackReducer</code> hooks to align with the new score-based feedback model. This includes adapting prop types, internal state management, and the logic for constructing and emitting feedback data, as well as updating all related Storybook documentation and unit tests to reflect the new API contract and behavior.<details><summary>Modified files (8)</summary><ul><li>src/components/vote-feedback.stories.tsx</li>
<li>src/components/vote-feedback.tsx</li>
<li>src/hooks/feedback-state/types.ts</li>
<li>src/hooks/feedback-state/use-feedback-reducer.stories.tsx</li>
<li>src/hooks/feedback-state/use-feedback-state.stories.tsx</li>
<li>src/hooks/feedback-state/use-feedback-state.test.ts</li>
<li>src/hooks/feedback-state/use-state-change-tracking.ts</li>
<li>src/ui/shadcn/vote-feedback.stories.tsx</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>almog.baku@gmail.com</td><td>chore-stricter-prettier</td><td>February 22, 2026</td></tr>
<tr><td>almog@kelet.ai</td><td>Feat-use-feedback-state-1</td><td>August 03, 2025</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/Kelet-ai/feedback-ui/6?tool=ast>(Baz)</a>.